### PR TITLE
Use non deprecated command name

### DIFF
--- a/cookbooks/workers.rst
+++ b/cookbooks/workers.rst
@@ -22,7 +22,7 @@ To deploy a worker, add an entry under the ``workers`` section:
                     set -x -e
 
                     (>&2 symfony-deploy)
-                    php bin/console messenger:consume-messages
+                    php bin/console messenger:consume
 
 On SymfonyCloud, worker containers run the exact same code as the web container.
 The container image is built only once, and then deployed multiple times in its


### PR DESCRIPTION
[prod.deprecations] Sep  6 12:58:07 |INFO | PHP    User Deprecated: The use of the "messenger:consume-messages" command is deprecated since version 4.3 and will be removed in 5.0. Use "messenger:consume" instead. exception="[object] (ErrorException(code: 0): User Deprecated: The use of the \"messenger:consume-messages\" command is deprecated since version 4.3 and will be removed in 5.0. Use \"messenger:consume\" instead. at /app/vendor/symfony/messenger/Command/ConsumeMessagesCommand.php:166)"