### PR TITLE
--tail is now the default

### DIFF
--- a/cookbooks/logs.rst
+++ b/cookbooks/logs.rst
@@ -70,7 +70,7 @@ uncaught exceptions. It also contains your application logs if you log on
     .. code-block:: terminal
 
         # tail on /app/app/logs/prod.log
-        $ symfony log prod --tail
+        $ symfony log prod
 
 ``cron.log``
 ~~~~~~~~~~~~


### PR DESCRIPTION
symfony log prod --tail

Usage:
  symfony env:logs [options] [--] [<types>]...

Arguments:
  types  
  
Options:
  --project=value, -p=value                      The project ID
  --environment=value, -e=value, --env=value     The environment ID [$SYMFONY_BRANCH, $SYMFONY_ENVIRONMENT]
  --app=value, -a=value, -A=value, --apps=value  The remote application names
  --worker=value                                 The remote worker names
  --no-follow, --no-tail                         [default: false]
  --lines=value, -n=value                        [default: 10]
  --no-humanize                                  Do not format JSON logs [default: false]
  --help, -h                                     Show help [default: false]
  

                                                         
  Incorrect usage: flag provided but not defined: -tail