### PR TITLE
Adding a space on a git command

### DIFF
--- a/getting-started.rst
+++ b/getting-started.rst
@@ -202,7 +202,7 @@ Commit the change:
 
 .. code-block:: terminal
 
-    $ git commit -a -m"Update text"
+    $ git commit -a -m "Update text"
     $ # in a real-life scenario, you would push the change to the upstream Git repository
 
 And deploy the change to the ``feat-a`` environment:


### PR DESCRIPTION
Adding a space between the option and the value for the git command on the "Getting Started" page: https://symfony.com/doc/master/cloud/getting-started.html