### PR TITLE
mailer now installs Symfony mailer

### DIFF
--- a/services/emails.rst
+++ b/services/emails.rst
@@ -37,7 +37,7 @@ On Symfony projects using Flex, install Swiftmailer:
 
 .. code-block:: terminal
 
-    $ composer require mailer
+    $ composer require swiftmailer
 
 No further configuration is needed as the default configuration knows how to use
 the value of ``MAILER_URL`` automatically.


### PR DESCRIPTION
Better would be to probably make the docs now focused on Symfony Mailer. I didn't check to see if that requires any other changes to the docs... so this was the easiest small change.

Reference: https://github.com/symfony/recipes/blob/339bf31cdbc0ad0f980a3ce8bc2edee3dee2aef4/symfony/mailer/4.3/manifest.json#L8