### PR TITLE
Introduce DOCtor-RST

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -1,0 +1,37 @@
+rules:
+    no_inheritdoc: ~
+    avoid_repetetive_words: ~
+    blank_line_after_directive: ~
+    short_array_syntax: ~
+    typo: ~
+    composer_dev_option_not_at_the_end: ~
+    yarn_dev_option_at_the_end: ~
+    versionadded_directive_should_have_version: ~
+    deprecated_directive_should_have_version: ~
+    no_composer_req: ~
+    no_php_open_tag_in_code_block_php_directive: ~
+    no_blank_line_after_filepath_in_php_code_block: ~
+    no_blank_line_after_filepath_in_yaml_code_block: ~
+    no_blank_line_after_filepath_in_xml_code_block: ~
+    no_blank_line_after_filepath_in_twig_code_block: ~
+    php_prefix_before_bin_console: ~
+    use_deprecated_directive_instead_of_versionadded: ~
+    no_space_before_self_xml_closing_tag: ~
+    no_explicit_use_of_code_block_php: ~
+    ensure_order_of_code_blocks_in_configuration_block: ~
+    american_english: ~
+    valid_use_statements: ~
+    lowercase_as_in_use_statements: ~
+    ordered_use_statements: ~
+    no_namespace_after_use_statements: ~
+    correct_code_block_directive_based_on_the_content: ~
+    max_blank_lines:
+        max: 2
+    replace_code_block_types: ~
+    use_https_xsd_urls: ~
+    blank_line_before_directive: ~
+    extension_xlf_instead_of_xliff: ~
+    valid_inline_highlighted_namespaces: ~
+    indention: ~
+    unused_links: ~
+    yaml_instead_of_yml_suffix: ~

--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -14,7 +14,6 @@ rules:
     no_blank_line_after_filepath_in_yaml_code_block: ~
     no_blank_line_after_filepath_in_xml_code_block: ~
     no_blank_line_after_filepath_in_twig_code_block: ~
-    php_prefix_before_bin_console: ~
     use_deprecated_directive_instead_of_versionadded: ~
     no_space_before_self_xml_closing_tag: ~
     no_explicit_use_of_code_block_php: ~

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,12 @@
+on: [push, pull_request]
+name: Lint
+jobs:
+    doctor-rst:
+        name: DOCtor-RST
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@master
+            - name: DOCtor-RST
+              uses: docker://oskarstark/doctor-rst
+              with:
+                  args: --short

--- a/cookbooks/cache.rst
+++ b/cookbooks/cache.rst
@@ -260,7 +260,6 @@ date included at the top of the content. With SSI, you can cache the date
 independently of the rest of the page::
 
     // src/Controller/DefaultController.php
-
     use Symfony\Component\HttpFoundation\Response;
     // ...
 

--- a/languages/php.rst
+++ b/languages/php.rst
@@ -355,7 +355,7 @@ site has lot of traffic). As an example, consider the following output:
 
 This indicates that the majority of requests (4800) used 2048 KB of memory. In
 this case that's likely application caching at work. Most requests used up to
-around 10 MB of memory, while a few used as much as 18 MB and a very very few
+around 10 MB of memory, while a few used as much as 18 MB and a very few
 (6 requests) peaked at 131 MB.
 
 A conservative approach would suggest an average request memory of 16 MB should

--- a/troubleshooting.rst
+++ b/troubleshooting.rst
@@ -15,6 +15,7 @@ They are four possible reasons to why you might encounter this error:
    upload it.
 
    .. caution::
+
        Please note that SymfonyCloud and SymfonyConnect SSH keys are currently
        differentiated: even if you previously uploaded your key to SymfonyConnect,
        you have to reupload it using the command mentionned above.

--- a/troubleshooting.rst
+++ b/troubleshooting.rst
@@ -152,7 +152,7 @@ upper. When migrating, one needs not to forget to define defaults in the
         // config/services.php
         $container->setParameter('env(DATABASE_URL)', 'mysql://db_user:db_password@127.0.0.1:3306/db_name');
 
-.. caution ::
+.. caution::
 
    Symfony applications created before November 2018 had a slightly different
    system, involving a ``.env.dist`` file. For information about upgrading, see:


### PR DESCRIPTION
DOCtor-RST is a linting tool (which runs as GithubAction), which is used at symfony-docs, sonata-project and EasyAdminBundle.

It checks the *.rst files for some specific conventions.

You can see it in Action here: https://github.com/symfony/symfony-docs/pull/13006/checks?check_run_id=414955239

We are using it since a few months for the symfony-docs and is developed by me 😄 

https://github.com/OskarStark/doctor-rst

PS: The GithubAction will first run, when its merged