### PR TITLE
Fix errors and warnings

### DIFF
--- a/config.rst
+++ b/config.rst
@@ -91,7 +91,7 @@ Type
 The **type** value defines the application language and the version to use.
 Current supported values are:
 
-* :ref:`php </languages/php>`
+* :doc:`php </languages/php>`
 * nodejs
 * python
 * ruby

--- a/cookbooks/cloudflare.rst
+++ b/cookbooks/cloudflare.rst
@@ -87,11 +87,11 @@ To enabled this setup, follow these steps:
    Cloudflare backend;
 2. Make sure the project has the "HTTP Proxy" feature enabled (orange cloud) in
    the "DNS" section of the Cloudflare backend;
-2. Download the Cloudflare Authenticated Origin Pulls CA certificate
+3. Download the Cloudflare Authenticated Origin Pulls CA certificate
    `origin-pull-ca.pem
    <https://support.cloudflare.com/hc/en-us/article_attachments/360044928032/origin-pull-ca.pem>`_
    and add it to the ``.symfony`` directory of the project to protect;
-3. Adapt the ``.symfony/routes.yaml`` file as follows:
+4. Adapt the ``.symfony/routes.yaml`` file as follows:
 
    .. code-block:: yaml
 
@@ -104,5 +104,5 @@ To enabled this setup, follow these steps:
                    - !include
                        type: string
                        path: origin-pull-ca.pem
-4. ``git add .symfony/origin-pull-ca.pem .symfony/routes.yaml && git commit``;
-5. ``symfony deploy``
+5. ``git add .symfony/origin-pull-ca.pem .symfony/routes.yaml && git commit``;
+6. ``symfony deploy``

--- a/cookbooks/go_live.rst
+++ b/cookbooks/go_live.rst
@@ -2,7 +2,6 @@ Going Live
 ==========
 
 .. contents::
-
     :depth: 1
     :local:
 

--- a/cookbooks/logs.rst
+++ b/cookbooks/logs.rst
@@ -76,7 +76,7 @@ uncaught exceptions. It also contains your application logs if you log on
 ~~~~~~~~~~~~
 
 The ``cron`` log contains the output of all recent executions of
-:ref:`cron jobs </cookbooks/crons>`. If there is no cron hook specified in the
+:doc:`cron jobs </cookbooks/crons>`. If there is no cron hook specified in the
 container configuration or if no cron has been executed yet, then this file will
 be absent.
 


### PR DESCRIPTION
I'm not an RST expert but here are the errors and warnings that sphinx was reporting locally.

* cookbooks/cloudflare.rst:90: WARNING: Enumerated list ends without a blank line; unexpected unindent.
* cookbooks/go_live.rst:4: ERROR: Error in "contents" directive:
* config.rst:94: WARNING: undefined label: /languages/php (if the link has no caption the label must precede a section header)
* cookbooks/logs.rst:78: WARNING: undefined label: /cookbooks/crons (if the link has no caption the label must precede a section header)