### PR TITLE
Add support for Redis 6.0

### DIFF
--- a/services/redis.rst
+++ b/services/redis.rst
@@ -29,9 +29,9 @@ To use it in your application, add it to ``.symfony/services.yaml``:
 .. code-block:: yaml
 
     myredis:
-        # supported versions: 3.2, 4.0, 5.0
+        # supported versions: 3.2, 4.0, 5.0, 6.0
         # 2.8 and 3.0 are also available but not maintained upstream
-        type: redis:5.0
+        type: redis:6.0
 
 Data in an Ephemeral Redis instance is stored only in memory, and thus requires
 no disk space. When the service hits its memory limit it will automatically
@@ -48,9 +48,9 @@ To use it in your application, add it to ``.symfony/services.yaml``:
 .. code-block:: yaml
 
     myredis:
-        # supported versions: 3.2, 4.0, 5.0
+        # supported versions: 3.2, 4.0, 5.0, 6.0
         # 2.8 and 3.0 are also available but not maintained upstream
-        type: redis-persistent:5.0
+        type: redis-persistent:6.0
         disk: 1024
 
 The ``disk`` key is required for redis-persistent to configure how much disk


### PR DESCRIPTION
Based on https://docs.platform.sh/configuration/services/redis.html#ephemeral-redis

I can support its working on my SfCloud instance:
```
      Opening environment
      Environment configuration
        app (type: php:7.4, size: S, disk: 512)
        redis (type: redis-persistent:6.0, size: S, disk: 1024)
```