### PR TITLE
Add PHP extensions to service wiring examples

### DIFF
--- a/services/memcached.rst
+++ b/services/memcached.rst
@@ -17,14 +17,14 @@ To use it in your application, add it to ``.symfony/services.yaml``:
         # supported versions: 1.4, 1.5, 1.6
         type: memcached:1.6
 
-And wire it in ``.symfony.cloud.yaml``:
+And wire it in ``.symfony.cloud.yaml`` (don't forget to enable the
+``memcached`` PHP extension):
 
 .. code-block:: yaml
 
     relationships:
         cache: "memcached:memcached"
 
-    # needed to install the PHP extension
     runtime:
         extensions:
             - memcached

--- a/services/mongodb.rst
+++ b/services/mongodb.rst
@@ -12,12 +12,17 @@ To use it in your application, add it to ``.symfony/services.yaml``:
         type: mongodb:3.0
         disk: 1024
 
-And wire it in ``.symfony.cloud.yaml``:
+And wire it in ``.symfony.cloud.yaml``  (don't forget to enable the
+``mongodb`` PHP extension)::
 
 .. code-block:: yaml
 
     relationships:
         mongodb: "mydatabase:mongodb"
+
+    runtime:
+        extensions:
+            - mongodb
 
 .. note::
 

--- a/services/mysql.rst
+++ b/services/mysql.rst
@@ -15,13 +15,18 @@ To use it in your application, add it to your ``.symfony/services.yaml``:
         type: mysql:10.4
         disk: 1024
 
-And wire it in ``.symfony.cloud.yaml``:
+And wire it in ``.symfony.cloud.yaml`` (don't forget to enable the
+``pdo_mysql`` PHP extension):
 
 .. code-block:: yaml
 
     # .symfony.cloud.yaml
     relationships:
         database: "mydatabase:mysql"
+
+    runtime:
+        extensions:
+            - pdo_mysql
 
 Oracle's `MySQL`_ is also available using ``oracle-mysql``:
 

--- a/services/rabbitmq.rst
+++ b/services/rabbitmq.rst
@@ -14,12 +14,17 @@ To use it in your application, add it to ``.symfony/services.yaml``:
         type: rabbitmq:3.7
         disk: 1500
 
-And wire it in ``.symfony.cloud.yaml``:
+And wire it in ``.symfony.cloud.yaml`` (don't forget to enable the
+``amqp`` PHP extension):
 
 .. code-block:: yaml
 
     relationships:
         rabbitmq: "myrabbitmq:rabbitmq"
+
+    runtime:
+        extensions:
+            - amqp
 
 The configuration is exposed via the following environment variables (where
 ``RABBITMQ`` is the upper-cased version of the key defined in the relationship


### PR DESCRIPTION
Was suggested at support and make sense as we already do it for PostgreSQL