### PR TITLE
Improves build cache dire doc

### DIFF
--- a/config.rst
+++ b/config.rst
@@ -413,10 +413,12 @@ Three hooks are available:
 
   .. note::
 
-    Build environments (the application plus the cache directory) are limited to
-    4 GB during the build step - independently of the mounted disk size that is
-    allocated for deployment. If you exceed this limit you will receive a ``No
-    space left on device error``.
+    Build environments (the application plus the build cache directory - not
+    limited to the ``app`` subdirectory) are limited to 4 GB during the build
+    step - independently of the mounted disk size that is allocated for
+    deployment. If you exceed this limit you will receive a ``No space left on
+    device error``. You can clear the build cache directory by using the
+    ``--clear-build-cache`` flag available on the ``symfony deploy`` command.
 
 .. _deploy-hook:
 

--- a/cookbooks/env.rst
+++ b/cookbooks/env.rst
@@ -167,17 +167,23 @@ will evaluate to an empty string like any other unset variable:
 
 .. _build_cache_dir:
 
-* ``SYMFONY_CACHE_DIR``: The absolute path to the build cache directory
-  available during the :ref:`build hook <build-hook>` execution.
+* ``SYMFONY_CACHE_DIR``: The absolute path to a subdirectory of the build cache
+  directory available during the :ref:`build hook <build-hook>` execution. This
+  subdirectory is reserved to your own use.
 
-  This directory is persisted between builds, but is **not** deployed. It’s a
-  good place to store build artifacts, such as downloaded files, that can be
-  reused between builds.
+  The build cache directory is persisted between builds, but is **not**
+  deployed. It’s a good place to store build artifacts, such as downloaded
+  files, that can be reused between builds.
 
   .. note::
 
      This directory is shared by **all** builds on **all** branches, make sure
      your build hook accounts for that.
+
+  .. tip::
+
+     If you need to clear the build cache directory, you can use the
+     ``--clear-build-cache`` flag on the ``symfony deploy`` command.
 
 The following variables exist **only** at runtime. If used in a build hook they
 will evaluate to an empty string like any other unset variable:


### PR DESCRIPTION
Explicitely mention the fact that `SYMFONY_CACHE_DIR` is a subdirectory of the cache build dir and the availability of the ``--clear-build-cache`` flag