### PR TITLE
Comment the "index" entry in the example config

### DIFF
--- a/config.rst
+++ b/config.rst
@@ -249,8 +249,7 @@ a specific configuration:
             "/":
                 root: "public"
                 passthru: "/index.php"
-                index:
-                    - index.php
+                #index: [ index.php ]
                 expires: -1
                 scripts: true
                 allow: true


### PR DESCRIPTION
Enabling this rule causes issues, where the Symfony app doesn't receive the request and a 503 is displayed instead.