### PR TITLE
Update mysql service name

### DIFF
--- a/services/mysql.rst
+++ b/services/mysql.rst
@@ -11,7 +11,7 @@ To use it in your application, add it to your ``.symfony/services.yaml``:
     mydatabase:
         # supported versions: 10.2, 10.3, 10.4, 10.5
         # 5.5, 10.0 and 10.1 are also available but not maintained upstream
-        type: mysql:10.4
+        type: mariadb:10.5
         disk: 1024
 
 And wire it in ``.symfony.cloud.yaml`` (don't forget to enable the


### PR DESCRIPTION
The docs says to use the `mysql` type and that MariaDB v10.5 is supported.

But as of MariaDB 10.5, the `mysql` alias is not working and you have to use `mariadb` instead.

Someone had this issue on Symfony Slack https://symfony-devs.slack.com/archives/CEFCGTYP5/p1614254713003200