### PR TITLE
New rule for DOCtor-RST

### DIFF
--- a/.doctor-rst.yaml
+++ b/.doctor-rst.yaml
@@ -34,6 +34,7 @@ rules:
     indention: ~
     unused_links: ~
     yaml_instead_of_yml_suffix: ~
+    ensure_link_definition_contains_valid_url: ~
 
 # do not report those as violation
 whitelist:


### PR DESCRIPTION
`ensure_link_definition_contains_valid_url`

Follows https://github.com/symfony/symfony-docs/pull/15313